### PR TITLE
Add superseded by specs as part of status line

### DIFF
--- a/xep-0119.xml
+++ b/xep-0119.xml
@@ -7,7 +7,7 @@
 <xep>
 <header>
   <title>Extended Presence Protocol Suite</title>
-  <abstract>This document specifies a set of XMPP extensions that provide support for extended presence information. Note: This document has been retracted since its functionality is handled by XEP-0163.</abstract>
+  <abstract>This document specifies a set of XMPP extensions that provide support for extended presence information.</abstract>
   &LEGALNOTICE;
   <number>0119</number>
   <status>Retracted</status>
@@ -81,7 +81,6 @@
   </revision>
 </header>
 <section1 topic='Introduction' anchor='intro'>
-  <p><em>Note: This document has been retracted since its functionality is handled by &xep0163;.</em></p>
   <p>A number of network services enable the exchange of information about an entity's availability for communications over the network. This information is usually called "presence". Examples include a person's availability to talk over a traditional or mobile telephony network, chat over an instant messaging (IM) network, or participate in a video conference. In this core sense, presence is a boolean, "on/off" indicator of network availability.</p>
   <p>Over time, this core notion of presence has been extended to include other information about the entity that either (1) changes quickly or (2) affects the entity's interest in or ability to engage in communications. Examples of such "extended presence" include a person's proximity to or interaction with a user agent (e.g., "away" or "do not disturb"), activity (e.g., "driving"), ambient environment (e.g., "noisy"), and mood (e.g., "grumpy"). Related information includes data about the person's available devices (e.g., "phone" or "IM"), current contact modes or address, and date/time ranges for availability. Because extended presence information can change quite often (e.g., several times in the course of a typical IM session), it is distinct from more stable information about the individual (such as is captured in a vCard or other user profile).</p>
   <p>This document describes a unified approach to the provision and communication of extended presence information using the Extensible Messaging and Presence Protocol (XMPP), in the form of a "protocol suite" that incorporates by reference a number of existing XMPP extensions.</p>

--- a/xep-0161.xml
+++ b/xep-0161.xml
@@ -7,7 +7,7 @@
 <xep>
 <header>
   <title>Abuse Reporting</title>
-  <abstract>This document specifies an XMPP protocol extension for reporting abusive XMPP stanzas. NOTE: This specification has been superseded by XEP-0268.</abstract>
+  <abstract>This document specifies an XMPP protocol extension for reporting abusive XMPP stanzas.</abstract>
   &LEGALNOTICE;
   <number>0161</number>
   <status>Deferred</status>
@@ -58,7 +58,6 @@
 </header>
 
 <section1 topic='Introduction' anchor='intro'>
-  <p>NOTE: This specification has been superseded by &xep0268;.</p>
   <p>Unfortunately, not all XMPP entities are well-behaved -- they may send spam of various kinds, harrass chat rooms, generate large amounts of traffic, etc. Currently, if an XMPP entity (the "attacker") sends abusive stanzas to another XMPP entity (the "victim"), there is no way for the victim or the victim's server to inform the attacker's server that the attacker is generating abusive traffic. In current practice, the victim's server may have no choice but to terminate the server-to-server connection rather than continue to accept the abusive traffic.</p>
   <p>This situation is far from desirable. Therefore, this specification defines several protocol functions that can help to discourage abuse on the XMPP network:</p>
   <ol>

--- a/xep-0270.xml
+++ b/xep-0270.xml
@@ -9,8 +9,6 @@
   <title>XMPP Compliance Suites 2010</title>
   <abstract>
     This document defines XMPP protocol compliance levels for 2010.
-    Note well that it has been superseded by XEP-0375: XMPP Compliance Suites
-    2016.
   </abstract>
   &LEGALNOTICE;
   <number>0270</number>

--- a/xep-0281.xml
+++ b/xep-0281.xml
@@ -9,7 +9,7 @@
 <xep>
 <header>
   <title>DMUC1: Distributed Multi-User Chat</title>
-  <abstract>This document defines methods for distributing Multi-User Chat (MUC) rooms across multiple chat services. Note: This document has been retracted by the author in favor of XEP-0289.</abstract>
+  <abstract>This document defines methods for distributing Multi-User Chat (MUC) rooms across multiple chat services.</abstract>
   &LEGALNOTICE;
   <number>0281</number>
   <status>Retracted</status>
@@ -52,8 +52,6 @@
 </header>
 
 <section1 topic='Introduction' anchor='intro'>
-
-  <p><em>Note: This document has been retracted by the author in favor of &xep0289;.</em></p>
 
   <section2 topic='Motivation' anchor='motivation'>
     <p>&xep0045; defines a full-featured technology for multi-user text conferencing in XMPP. By design, <cite>XEP-0045</cite> assumes that a conference room is hosted at a single service, which can be accessed from any point on the network. However, this assumption introduces a single point of failure for the conference room, since if occupants at a using domain lose connectivity to the hosting domain then they also lose connectivity to the room. In some deployment scenarios (and even on the open Internet) this behavior is suboptimal. Therefore, this document attempts to define a technology for distributing MUC rooms across multiple services.</p>

--- a/xep-0281.xml
+++ b/xep-0281.xml
@@ -20,7 +20,9 @@
     <spec>XEP-0030</spec>
   </dependencies>
   <supersedes/>
-  <supersededby/>
+  <supersededby>
+    <spec>XEP-0289</spec>
+  </supersededby>
   <shortname>NOT-YET-ASSIGNED</shortname>
   &stpeter;
   <revision>

--- a/xep-0289.xml
+++ b/xep-0289.xml
@@ -18,7 +18,9 @@
     <spec>XMPP Core</spec>
     <spec>XEP-0045</spec>
   </dependencies>
-  <supersedes/>
+  <supersedes>
+    <spec>XEP-0281</spec>
+  </supersedes>
   <supersededby/>
   <shortname>FMUC</shortname>
   &ksmithisode;

--- a/xep.xsl
+++ b/xep.xsl
@@ -103,7 +103,19 @@ OR OTHER DEALINGS IN THE SOFTWARE.
         <table>
           <tr valign='top'>
             <td><strong>Abstract:</strong></td>
-            <td><xsl:value-of select='/xep/header/abstract'/></td>
+            <td>
+              <xsl:value-of select='/xep/header/abstract'/>
+              <xsl:variable name='supersededby.count' select='count(/xep/header/supersededby/spec)'/>
+              <xsl:if test='$supersededby.count &gt; 0'>
+                <xsl:text> </xsl:text>
+                <strong>
+                  <xsl:text>Note well that it has been superseded by: </xsl:text>
+                  <xsl:apply-templates select='/xep/header/supersededby/spec'>
+                    <xsl:with-param name='speccount' select='$supersededby.count'/>
+                  </xsl:apply-templates>
+                </strong>
+              </xsl:if>
+            </td>
           </tr>
           <xsl:if test='$authors.count=1'>
             <tr valign='top'>

--- a/xep.xsl
+++ b/xep.xsl
@@ -105,16 +105,6 @@ OR OTHER DEALINGS IN THE SOFTWARE.
             <td><strong>Abstract:</strong></td>
             <td>
               <xsl:value-of select='/xep/header/abstract'/>
-              <xsl:variable name='supersededby.count' select='count(/xep/header/supersededby/spec)'/>
-              <xsl:if test='$supersededby.count &gt; 0'>
-                <xsl:text> </xsl:text>
-                <strong>
-                  <xsl:text>Note well that it has been superseded by: </xsl:text>
-                  <xsl:apply-templates select='/xep/header/supersededby/spec'>
-                    <xsl:with-param name='speccount' select='$supersededby.count'/>
-                  </xsl:apply-templates>
-                </strong>
-              </xsl:if>
             </td>
           </tr>
           <xsl:if test='$authors.count=1'>
@@ -181,7 +171,19 @@ OR OTHER DEALINGS IN THE SOFTWARE.
           <p style='color:red'>WARNING: This document has been automatically Deferred after 12 months of inactivity in its previous Experimental state. Implementation of the protocol described herein is not recommended for production systems. However, exploratory implementations are encouraged to resume the standards process.</p>
         </xsl:if>
         <xsl:if test='$thestatus = "Deprecated"'>
-          <p style='color:red'>WARNING: This document has been <strong>Deprecated</strong> by the XMPP Standards Foundation. Implementation of the protocol described herein is not recommended. Developers desiring similar functionality are advised to implement the protocol that supersedes this one (if any).</p>
+          <p style='color:red'>WARNING: This document has been <strong>Deprecated</strong> by the XMPP Standards Foundation. Implementation of the protocol described herein is not recommended. Developers desiring similar functionality are advised to implement the protocol that supersedes this one
+            <xsl:variable name='supersededby.count' select='count(/xep/header/supersededby/spec)'/>
+            <xsl:choose>
+              <xsl:when test='$supersededby.count &gt; 0'>
+                <xsl:text>(</xsl:text>
+                <xsl:apply-templates select='/xep/header/supersededby/spec'>
+                  <xsl:with-param name='speccount' select='$supersededby.count'/>
+                </xsl:apply-templates>
+                <xsl:text>).</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>(if any).</xsl:otherwise>
+            </xsl:choose>
+          </p>
         </xsl:if>
         <xsl:if test='$thestatus = "Draft"'>
           <p style='color:green'>NOTICE: The protocol defined herein is a <strong>Draft Standard</strong> of the XMPP Standards Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
@@ -202,7 +204,19 @@ OR OTHER DEALINGS IN THE SOFTWARE.
           <p style='color:green'>NOTICE: The protocol defined herein is a <strong>Final Standard</strong> of the XMPP Standards Foundation and can be considered a stable technology for implementation and deployment.</p>
         </xsl:if>
         <xsl:if test='$thestatus = "Obsolete"'>
-          <p style='color:red'>WARNING: This document has been obsoleted by the XMPP Standards Foundation. Implementation of the protocol described herein is not recommended. Developers desiring similar functionality are advised to implement the protocol that supersedes this one (if any).</p>
+          <p style='color:red'>WARNING: This document has been obsoleted by the XMPP Standards Foundation. Implementation of the protocol described herein is not recommended. Developers desiring similar functionality are advised to implement the protocol that supersedes this on
+            <xsl:variable name='supersededby.count' select='count(/xep/header/supersededby/spec)'/>
+            <xsl:choose>
+              <xsl:when test='$supersededby.count &gt; 0'>
+                <xsl:text>(</xsl:text>
+                <xsl:apply-templates select='/xep/header/supersededby/spec'>
+                  <xsl:with-param name='speccount' select='$supersededby.count'/>
+                </xsl:apply-templates>
+                <xsl:text>).</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>(if any).</xsl:otherwise>
+            </xsl:choose>
+          </p>
         </xsl:if>
         <xsl:if test='$thestatus = "Proposed"'>
           <p style='color:red'>NOTICE: This document is currently within Last Call or under consideration by the XMPP Council for advancement to the next stage in the XSF standards process.
@@ -217,7 +231,19 @@ OR OTHER DEALINGS IN THE SOFTWARE.
           <p style='color:red'>WARNING: This document has been Rejected by the XMPP Council. Implementation of the protocol described herein is not recommended under any circumstances.</p>
         </xsl:if>
         <xsl:if test='$thestatus = "Retracted"'>
-          <p style='color:red'>WARNING: This document has been retracted by the author(s). Implementation of the protocol described herein is not recommended. Developers desiring similar functionality are advised to implement the protocol that supersedes this one (if any).</p>
+          <p style='color:red'>WARNING: This document has been retracted by the author(s). Implementation of the protocol described herein is not recommended. Developers desiring similar functionality are advised to implement the protocol that supersedes this one
+            <xsl:variable name='supersededby.count' select='count(/xep/header/supersededby/spec)'/>
+            <xsl:choose>
+              <xsl:when test='$supersededby.count &gt; 0'>
+                <xsl:text>(</xsl:text>
+                <xsl:apply-templates select='/xep/header/supersededby/spec'>
+                  <xsl:with-param name='speccount' select='$supersededby.count'/>
+                </xsl:apply-templates>
+                <xsl:text>).</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>(if any).</xsl:otherwise>
+            </xsl:choose>
+          </p>
         </xsl:if>
         <!-- TABLE OF CONTENTS -->
         <hr />


### PR DESCRIPTION
I'm not sure if this is better or not; it's less visible, but it makes more sense semantically in my mind. I suppose they're not mutually exclusive either; anyways, I'll submit a PR and leave it up to your disgression.

![header](https://cloud.githubusercontent.com/assets/512573/22400332/53f015c0-e577-11e6-8088-7b34bc7bd11f.png)
